### PR TITLE
Rebuild with openblas on windows

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/openblas-feedstock/pr13/66809d1
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/63a47e9

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/openblas-feedstock/pr13/66809d1
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/63a47e9

--- a/recipe/CMakeLists.txt
+++ b/recipe/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project (dsdp VERSION 5.8 LANGUAGES C)
 
 link_directories(${LIBRARY_PREFIX}/lib)

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,18 +1,6 @@
 mkl:
   - 2025
 
-numpy:
-  # python 3.10
-  - 2.4.4
-  # python 3.11
-  - 2.4.4
-  # python 3.12
-  - 2.4.4
-  # python 3.13
-  - 2.4.4
-  # python 3.14
-  - 2.4.4
-
 blas_impl:
   - mkl                        # [(x86 or x86_64) and not osx]
   - openblas

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,18 @@
 mkl:
   - 2025
+
+numpy:
+  # python 3.10
+  - 2.4.4
+  # python 3.11
+  - 2.4.4
+  # python 3.12
+  - 2.4.4
+  # python 3.13
+  - 2.4.4
+  # python 3.14
+  - 2.4.4
+
+blas_impl:
+  - mkl                        # [(x86 or x86_64) and not osx]
+  - openblas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,15 +15,14 @@ source:
 build:
   # Openblas requires VS >=2015.  MKL is OK with VS 2008.
   skip: true  # [win and vc<14 and blas_impl == "openblas"]
-  number: 3
+  number: 4
 
 requirements:
   build:
     - cmake
     - {{ compiler("c") }}
+    - {{ stdlib("c") }}
     - make   # [unix]
-    - patch       # [not win]
-    - m2-patch    # [win]
  
   host:
     - mkl-devel {{ mkl }}            # [blas_impl == "mkl"]


### PR DESCRIPTION
dsps rebuild with openblas variant on windows.

https://anaconda.atlassian.net/browse/PKG-13576

### Changes
- Add openblas to build matrix to build openblas variant on windows.
- Remove `patch` and add stdlib to match current recipe standards. 